### PR TITLE
Fix SOA record parsing when missing trailing '.'.

### DIFF
--- a/classes/bind.php
+++ b/classes/bind.php
@@ -179,7 +179,7 @@
 					$end = substr($name, strlen($name) - $len);
 
 					if ($type == 'SOA') {
-						if ($name == $origin) {
+						if ($name == $origin || $name.'.' == $origin) {
 							$name = $this->domain . '.';
 						}
 					} else {


### PR DESCRIPTION
Cloudflare exports don't have a trailing '.' on the name of the
SOA record, e.g.:

   domain.tld SOA domain.tld admin.domain.tld 2038080112 7200 3600 86400 3600

This check was added in b257d8014305b9bc4085a7268a46bb20a7367184
to work around that, but it doesn't work with recent exports.

I think cloudflare used to have an $origin directive, but my exports
no longer have that. $origin defaults to domain + '.', which means
the check ends up evaluating to something like:

   if ($name == "domain.tld.") {
     $name = "domain.tld.";
   }

... which is obviously a little dumb. There might be a more elegant
way of solving this, but adding an extra check with a period appended
seems like a definite fix that would still cope with custom $origins
and whatnot.